### PR TITLE
use List::Util instead of List::MoreUtils

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ readme_from 'lib/Data/Visitor/Lite.pm';
 githubmeta;
 
 requires 'Data::Util';
-requires 'List::MoreUtils';
+requires 'List::Util' => '1.33';
 requires 'Scalar::Util';
 requires 'Carp';
 

--- a/lib/Data/Visitor/Lite.pm
+++ b/lib/Data/Visitor/Lite.pm
@@ -5,7 +5,7 @@ no warnings 'recursion';
 use Carp qw/croak/;
 use Data::Util qw/:check/;
 use Scalar::Util qw/blessed refaddr/;
-use List::MoreUtils qw/all/;
+use List::Util qw/all/;
 
 use constant AS_HASH_KEY => 1;
 our $VERSION = '0.03';


### PR DESCRIPTION
List::Util 1.33 contains the 'all' function so the List::MoreUtils dependency is not needed.